### PR TITLE
Handle OSError during select

### DIFF
--- a/swigibpy.py
+++ b/swigibpy.py
@@ -2010,7 +2010,7 @@ TagValue_swigregister(TagValue)
 
 import sys
 import threading
-from select import select
+import select
 from traceback import print_exc, print_exception
 
 
@@ -2036,20 +2036,24 @@ class TWSPoller(threading.Thread):
         pollerr = [fd]
 
         while self._tws and self._tws.isConnected():
-            evts = select(pollin, pollout, pollerr)
-            if fd in evts[0]:
-                try:
-                    while self._tws.checkMessages():
-                        pass
-                except (SystemExit, SystemError, KeyboardInterrupt):
-                    break
-                except:
-                    try:
-                        self._wrapper.pyError(*sys.exc_info())
-                    except:
-                        print_exc()
-            else:
+            try:
+                evts = select.select(pollin, pollout, pollerr)
+            except select.error:
                 break
+            else:
+                if fd in evts[0]:
+                    try:
+                        while self._tws.checkMessages():
+                            pass
+                    except (SystemExit, SystemError, KeyboardInterrupt):
+                        break
+                    except:
+                        try:
+                            self._wrapper.pyError(*sys.exc_info())
+                        except:
+                            print_exc()
+                else:
+                    break
 
 class EPosixClientSocket(EClientSocketBase):
     """Proxy of C++ EPosixClientSocket class"""

--- a/swigify_ib.i
+++ b/swigify_ib.i
@@ -140,7 +140,7 @@ typedef std::string IBString;
 %pythoncode %{
 import sys
 import threading
-from select import select
+import select
 from traceback import print_exc, print_exception
 
 
@@ -166,20 +166,24 @@ class TWSPoller(threading.Thread):
         pollerr = [fd]
 
         while self._tws and self._tws.isConnected():
-            evts = select(pollin, pollout, pollerr)
-            if fd in evts[0]:
-                try:
-                    while self._tws.checkMessages():
-                        pass
-                except (SystemExit, SystemError, KeyboardInterrupt):
-                    break
-                except:
-                    try:
-                        self._wrapper.pyError(*sys.exc_info())
-                    except:
-                        print_exc()
-            else:
+            try:
+                evts = select.select(pollin, pollout, pollerr)
+            except select.error:
                 break
+            else:
+                if fd in evts[0]:
+                    try:
+                        while self._tws.checkMessages():
+                            pass
+                    except (SystemExit, SystemError, KeyboardInterrupt):
+                        break
+                    except:
+                        try:
+                            self._wrapper.pyError(*sys.exc_info())
+                        except:
+                            print_exc()
+                else:
+                    break
 %}
 
 %feature("pythonappend") EPosixClientSocket::EPosixClientSocket(EWrapper *ptr) %{


### PR DESCRIPTION
When a user calls tws.eDisconnect() then the poller thread ends up in an exception:
`OSError: [Errno 9] Bad file descriptor`

This happens because once the file descriptor is closed, then `select()` call in the `TWSPoller` thread returns with the bad file descriptor error.

With the changes in this pull request, the `select()` call is surrounded by try catch. Catching an OSError terminates the TWSPoller thread silently instead of printing the exception.

(In the examples this behaviour is not visible because the interpreter normally exits right after tws.eDisconnect() is called and with the termination of the interpreter the poller thread is killed before select returns (because of the `daemon=True` flag.))