### PR TITLE
Need to add winsock header on Cygwin

### DIFF
--- a/IB/src/EPosixClientSocket.cpp
+++ b/IB/src/EPosixClientSocket.cpp
@@ -7,6 +7,10 @@
 #include "TwsSocketClientErrors.h"
 #include "EWrapper.h"
 
+#ifdef __CYGWIN__
+#include "sys/socket.h"
+#endif
+
 #include <string.h>
 
 ///////////////////////////////////////////////////////////

--- a/IB/src/EPosixClientSocket.cpp
+++ b/IB/src/EPosixClientSocket.cpp
@@ -7,10 +7,6 @@
 #include "TwsSocketClientErrors.h"
 #include "EWrapper.h"
 
-#ifdef __CYGWIN__
-#include "sys/socket.h"
-#endif
-
 #include <string.h>
 
 ///////////////////////////////////////////////////////////

--- a/patches/winsock_cygwin
+++ b/patches/winsock_cygwin
@@ -1,0 +1,15 @@
+diff --git a/IB/src/EPosixClientSocket.cpp b/IB/src/EPosixClientSocket.cpp
+index 324e972..70a1904 100644
+--- a/IB/src/EPosixClientSocket.cpp
++++ b/IB/src/EPosixClientSocket.cpp
+@@ -7,6 +7,10 @@
+ #include "TwsSocketClientErrors.h"
+ #include "EWrapper.h"
+ 
++#ifdef __CYGWIN__
++#include "sys/socket.h"
++#endif
++
+ #include <string.h>
+ 
+ ///////////////////////////////////////////////////////////


### PR DESCRIPTION
Must add sys/socket.h to make swigibpy work on Cygwin.  Without it setup.py fails:

```
IB/src/EPosixClientSocket.cpp: In member function ‘virtual bool EPosixClientSocket::eConnect(const char*, unsigned int, int, bool)’:
IB/src/EPosixClientSocket.cpp:43:39: error: ‘socket’ was not declared in this scope
  m_fd = socket(AF_INET, SOCK_STREAM, 0);
                                       ^
IB/src/EPosixClientSocket.cpp:66:58: error: ‘connect’ was not declared in this scope
  if( (connect( m_fd, (struct sockaddr *) &sa, sizeof( sa))) < 0) {
                                                          ^
IB/src/EPosixClientSocket.cpp: In member function ‘virtual int EPosixClientSocket::send(const char*, size_t)’:
IB/src/EPosixClientSocket.cpp:130:16: error: ‘::send’ has not been declared
  int nResult = ::send( m_fd, buf, sz, 0);
                ^
IB/src/EPosixClientSocket.cpp: In member function ‘virtual int EPosixClientSocket::receive(char*, size_t)’:
IB/src/EPosixClientSocket.cpp:146:16: error: ‘::recv’ has not been declared
  int nResult = ::recv( m_fd, buf, sz, 0);
                ^
error: command 'gcc' failed with exit status 1
```
