### PR TITLE
patch for snprintf fix needed for Windows 64 bit python when building with VS2008

### DIFF
--- a/IB/shared/EClientSocketBaseImpl.h
+++ b/IB/shared/EClientSocketBaseImpl.h
@@ -25,6 +25,43 @@
 #include <string.h>
 #include <assert.h>
 
+
+//from http://stackoverflow.com/questions/2915672/snprintf-and-visual-studio-2010
+#if defined(_MSC_VER) && _MSC_VER < 1900
+
+//va_start and va_end require stdarg.h
+//from http://stackoverflow.com/questions/9885370/va-list-in-c-64-bits
+#include <stdarg.h>
+
+#define snprintf c99_snprintf
+#define vsnprintf c99_vsnprintf
+
+inline int c99_vsnprintf(char *outBuf, size_t size, const char *format, va_list ap)
+{
+    int count = -1;
+
+    if (size != 0)
+        count = _vsnprintf_s(outBuf, size, _TRUNCATE, format, ap);
+    if (count == -1)
+        count = _vscprintf(format, ap);
+
+    return count;
+}
+
+inline int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
+{
+    int count;
+    va_list ap;
+
+    va_start(ap, format);
+    count = c99_vsnprintf(outBuf, size, format, ap);
+    va_end(ap);
+
+    return count;
+}
+
+#endif
+
 /////////////////////////////////////////////////////////////////////////////////
 // SOCKET CLIENT VERSION CHANGE LOG : Incremented when the format of incomming
 //                                    server responses change

--- a/patches/snprintf_visual_studio
+++ b/patches/snprintf_visual_studio
@@ -1,0 +1,48 @@
+diff --git a/IB/shared/EClientSocketBaseImpl.h b/IB/shared/EClientSocketBaseImpl.h
+index c4d6fb4..1d836c4 100644
+--- a/IB/shared/EClientSocketBaseImpl.h
++++ b/IB/shared/EClientSocketBaseImpl.h
+@@ -25,6 +25,43 @@
+ #include <string.h>
+ #include <assert.h>
+ 
++
++//from http://stackoverflow.com/questions/2915672/snprintf-and-visual-studio-2010
++#if defined(_MSC_VER) && _MSC_VER < 1900
++
++//va_start and va_end require stdarg.h
++//from http://stackoverflow.com/questions/9885370/va-list-in-c-64-bits
++#include <stdarg.h>
++
++#define snprintf c99_snprintf
++#define vsnprintf c99_vsnprintf
++
++inline int c99_vsnprintf(char *outBuf, size_t size, const char *format, va_list ap)
++{
++    int count = -1;
++
++    if (size != 0)
++        count = _vsnprintf_s(outBuf, size, _TRUNCATE, format, ap);
++    if (count == -1)
++        count = _vscprintf(format, ap);
++
++    return count;
++}
++
++inline int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
++{
++    int count;
++    va_list ap;
++
++    va_start(ap, format);
++    count = c99_vsnprintf(outBuf, size, format, ap);
++    va_end(ap);
++
++    return count;
++}
++
++#endif
++
+ /////////////////////////////////////////////////////////////////////////////////
+ // SOCKET CLIENT VERSION CHANGE LOG : Incremented when the format of incomming
+ //                                    server responses change


### PR DESCRIPTION
Fixes the following error when running setup.py install:

```
.\Microsoft\Visual C++ for Python\VC\Bin\amd64\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -DIB_USE_STD_STRING=1 -IIB -IIB/src -IIB/shared -IC:\...\python-2.7.10_x64\include -I...\PC /TpIB/src/EClientSocketBase.cpp /Fobuild\temp.win-amd64-2.7\Release\IB/src/EClientSocketBase.obj /D_CRT_SECURE_NO_DEPRECATE /EHsc /wd4355 /wd4800
EClientSocketBase.cpp
IB/shared\EClientSocketBaseImpl.h(308) : error C3861: 'snprintf': identifier not found
```

I ran into this on 64 bit Windows Python with Visual Studio 2008
